### PR TITLE
[TSK-388] Make the message date get displayed in a day/month order

### DIFF
--- a/lib/components/conversation/message.tsx
+++ b/lib/components/conversation/message.tsx
@@ -38,9 +38,10 @@ export const ConversationMessage = ({
 }: TMessage) => {
   const createdAtInt = created_at ? parseInt(created_at) : NaN;
 
+  // TODO: handle locale
   const formattedDate = isNaN(createdAtInt)
     ? ""
-    : new Date(createdAtInt).toLocaleString("en-US", {
+    : new Date(createdAtInt).toLocaleString("en-UK", {
         year: "numeric",
         month: "2-digit",
         day: "2-digit",


### PR DESCRIPTION
Fix #32 

The locale was changed to UK, but in the future it should be configurable.

I suggest using the formatDate function from #36 on merging the fix