### PR TITLE
Fix header's z index

### DIFF
--- a/lib/components/site-header/SiteHeader.tsx
+++ b/lib/components/site-header/SiteHeader.tsx
@@ -18,7 +18,7 @@ export const Header = (props: HeaderProps) => {
   return (
     <header
       className={cn(
-        "sticky top-0 bg-neutral-100 text-neutral-800 dark:bg-neutral-800 shadow-lg",
+        "sticky z-[100] top-0 bg-neutral-100 text-neutral-800 dark:bg-neutral-800 shadow-lg",
       )}
     >
       <div


### PR DESCRIPTION
Fix #81. Header being on top of the chat elements ensures no visible overflow